### PR TITLE
Add a pre-commit hook to format code (#45)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,11 @@ Patch standards:
 
 - Format your code with `black`.
 
+  On Linux and OS X, you can enable the included pre-commit hook to automate this:
+  ```bash
+  ln -snfr infra/pre-commit .git/hooks/pre-commit
+  ```
+
 - Include tests if you're changing code. Your tests should succeed with your
   patch and fail without it.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ documentation about Ambuda's technical design.
 How to contribute
 -----------------
 
-For details on how to contribute to Ambuda, see `CONTRIBUDING.md`. We also
+For details on how to contribute to Ambuda, see [`CONTRIBUTING.md`][CONTRIBUTING.md]. We also
 strongly recommend joining our [Discord channel][discord], where we have an
 ongoing informal discussion about Ambuda's technical problems and roadmap.
 
 [discord]: https://discord.gg/7rGdTyWY7Z
+[CONTRIBUTING.md]: /CONTRIBUTING.md

--- a/infra/pre-commit
+++ b/infra/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Runs 'black' over all modified Python files.
+
+# Look for any added or modified (but not deleted) Python files in the diff.
+modified_python_files=`git diff "$@" --no-prefix --cached --name-only --diff-filter=d -- '***.py'`
+
+if [ -n "${modified_python_files}" ]; then
+    # When black is not available or fails to run, refuse to commit
+    { black --version && black ${modified_python_files}; } \
+        || \
+        { echo "Failed to format with 'black', refusing to commit." \
+               "Please ensure you have black installed: 'python -m pip install black'." \
+               "Alternatively, you can skip the pre-commit hook by" \
+               "commiting with the '--no-verify' option." && exit 1 \
+        ;}
+fi
+
+# Need to add the files again since the hook might have modified them.
+git add ${modified_python_files}


### PR DESCRIPTION
Adds a pre-commit hook under a new `infra/` directory that will
automatically format modified Python files with `Black`.

Also fixes a minor typo in the top-level README.