### PR TITLE
Add support for different font sizes

### DIFF
--- a/ambuda/static/js/main.js
+++ b/ambuda/static/js/main.js
@@ -67,6 +67,18 @@ const Preferences = {
   set dictVersion(value) {
     localStorage.setItem('dict-version', value);
   },
+  get contentFontSize() {
+    const ls = localStorage.getItem('user-font-size');
+    if (!ls || ls === 'undefined') {
+      return 'md:text-xl';
+    }
+    return ls;
+  },
+  set contentFontSize(value) {
+    if (value) {
+      localStorage.setItem('user-font-size', value);
+    }
+  },
 };
 
 // Utilities
@@ -248,6 +260,11 @@ const ParseLayer = (() => {
 })();
 
 const TextContent = (() => {
+  function changeFontSize(from, to) {
+    const $contentClass = $('#text--content');
+    $contentClass.classList.replace(from, to);
+  }
+
   function transliterate(from, to) {
     const $textContent = $('#text--content');
     if ($textContent) {
@@ -353,7 +370,7 @@ const TextContent = (() => {
     }
   }
 
-  return { init, transliterate };
+  return { init, transliterate, changeFontSize };
 })();
 
 const ScriptMenu = (() => {
@@ -376,11 +393,33 @@ const ScriptMenu = (() => {
   return { init };
 })();
 
+const FontSizeMenu = (() => {
+  function switchFontSize(newFontSize) {
+    const oldFontSize = Preferences.contentFontSize;
+    Preferences.contentFontSize = newFontSize;
+    TextContent.changeFontSize(oldFontSize, newFontSize);
+  }
+
+  function init() {
+    const $fontSizeMenu = $('#switch-font-size');
+    if ($fontSizeMenu) {
+      $fontSizeMenu.value = Preferences.contentFontSize;
+      $fontSizeMenu.addEventListener('change', (e) => {
+        switchFontSize(e.target.value);
+      });
+    }
+  }
+
+  return { init };
+})();
+
 (() => {
+  FontSizeMenu.init();
   ScriptMenu.init();
   Dictionary.init();
   ParseLayer.init();
   TextContent.init();
 
+  TextContent.changeFontSize('md:text-xl', Preferences.contentFontSize);
   TextContent.transliterate('devanagari', Preferences.contentScript);
 })();

--- a/ambuda/templates/htmx/text-section.html
+++ b/ambuda/templates/htmx/text-section.html
@@ -33,7 +33,13 @@
   {{ section.title | devanagari }}
 </div>
 <div class="flex items-center">
-  <div class="text-sm border-r pr-4">
+  <div class="hidden md:inline text-sm border-r px-4">
+    <span class="hidden md:inline">Font Size:</span>
+    <select id="switch-font-size" class="p-1">
+      {% include 'include/font-size-options.html' %}
+    </select>
+  </div>
+  <div class="text-sm border-r px-4">
     <span class="hidden md:inline">Script:</span>
     <select id="switch-sa" class="p-1">
       {% include 'include/script-options.html' %}

--- a/ambuda/templates/include/font-size-options.html
+++ b/ambuda/templates/include/font-size-options.html
@@ -1,0 +1,5 @@
+<option value="md:text-base">Tiny</option>
+<option value="md:text-lg">Small</option>
+<option value="md:text-xl" selected>Medium</option>
+<option value="md:text-2xl">Large</option>
+<option value="md:text-3xl">X-Large</option>


### PR DESCRIPTION
Adds support to change font size of texts.

Mapping of fontsizes supported by Tailwind to the selection available in the menu:
text-base -> Tiny
text-lg -> Small
text-xl" selected>Medium
text-2xl -> Large
text-3xl -> X-Large