### PR TITLE
Remove unused PyMuPDF from requirements.txt

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ file is quite messy right now, but the major dependencies are:
 
 You can install them with::
 
-    $ python -m venv env
+    $ python3 -m venv env
     $ . env/bin/activate
     $ pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,6 @@ pyasn1-modules==0.2.8
 pycparser==2.21
 Pygments==2.12.0
 pykakasi==2.2.1
-PyMuPDF==1.20.1
 PyNaCl==1.5.0
 pyOpenSSL==22.0.0
 pyparsing==3.0.9


### PR DESCRIPTION
It was hard to set up in my local dev environment (first complained
about swig not being installed, then fitz.h header): turns out it's
not even used, so simpler to just remove it.

Also updated "python" to "python3" in the installation instructions,
as it doesn't exist on my system (which is not unusual, see PEP 394):
the other invocations are ok as they happen inside the venv where it
("python") is available.